### PR TITLE
DOCS Add composer require + explicit MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Single page administration via a LeftAndMain like interface. Let your clients ed
 
 Installation via composer
 
+```bash
+$ composer require littlegiant/silverstripe-singlepageadmin
+```
+
 ## How to use
 
 Simply extend the SinglePageAdmin class instead of ModelAdmin and include the class via the `tree_class` static.
@@ -33,7 +37,27 @@ to ensure that the class has one and only one instance created, usually via canC
 
 ## License
 
-SilverStripe Single Page Administration is released under the MIT license
+The MIT License (MIT)
+
+Copyright (c) 2015 Little Giant Design Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ## Contributing
 


### PR DESCRIPTION
Means people can copy and paste the composer install and without actually having the MIT license stated explicitly the code remains copyright Little Giant with all rights being reserved. 

Adding the licence effectively is what 'open sources' the code :+1: You could also look at putting this in a separate LICENSE.md file if you like too.
