### PR TITLE
Revert SinglePageAdmin to concrete class

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,6 @@
+<?php
+
+use LittleGiant\SinglePageAdmin\SinglePageAdmin;
+use SilverStripe\Admin\CMSMenu;
+
+CMSMenu::remove_menu_class(SinglePageAdmin::class);

--- a/src/LittleGiant/SinglePageAdmin/SinglePageAdmin.php
+++ b/src/LittleGiant/SinglePageAdmin/SinglePageAdmin.php
@@ -31,7 +31,7 @@ use SilverStripe\View\Requirements;
  * @package SinglePageAdmin
  * @author Stevie Mayhew
  */
-abstract class SinglePageAdmin extends LeftAndMain implements PermissionProvider
+class SinglePageAdmin extends LeftAndMain implements PermissionProvider
 {
     /**
      * As of 4.0 all subclasses of LeftAndMain have to have a


### PR DESCRIPTION
PermissionProviders are instantiated when loading admin sections that allow users to change user/group permissions.