### PR TITLE
Fix issue with tab state restoration when returning from GridField

### DIFF
--- a/src/LittleGiant/SinglePageAdmin/SinglePageAdmin.php
+++ b/src/LittleGiant/SinglePageAdmin/SinglePageAdmin.php
@@ -568,4 +568,11 @@ class SinglePageAdmin extends LeftAndMain implements PermissionProvider
         }
     }
 
+    /**
+     * @return string
+     */
+    public function Backlink()
+    {
+        return $this->Link();
+    }
 }

--- a/templates/LittleGiant/SinglePageAdmin/Includes/SinglePageAdmin_Content.ss
+++ b/templates/LittleGiant/SinglePageAdmin/Includes/SinglePageAdmin_Content.ss
@@ -7,18 +7,6 @@
                 <% if $BreadcrumbsBackLink %><a href="$BreadcrumbsBackLink" class="btn btn-secondary btn--no-text font-icon-left-open-big hidden-lg-up toolbar__back-button"></a><% end_if %>
                 <% include SilverStripe\\Admin\\CMSBreadcrumbs %>
             </div>
-
-            <% if $EditForm.Fields.hasTabset %>
-                <% with $EditForm.Fields.fieldByName('Root') %>
-                    <div class="cms-content-header-tabs cms-tabset">
-                        <ul class="cms-tabset-nav-primary nav nav-tabs">
-                            <% loop $Tabs %>
-                                <li class="nav-item<% if $extraClass %> $extraClass<% end_if %>"><a href="#$id">$Title</a></li>
-                            <% end_loop %>
-                        </ul>
-                    </div>
-                <% end_with %>
-            <% end_if %>
         </div>
 
         <div class="flexbox-area-grow fill-height">

--- a/templates/LittleGiant/SinglePageAdmin/Includes/SinglePageAdmin_EditForm.ss
+++ b/templates/LittleGiant/SinglePageAdmin/Includes/SinglePageAdmin_EditForm.ss
@@ -10,21 +10,7 @@
         <fieldset>
             <% if $Legend %><legend>$Legend</legend><% end_if %>
             <% loop $Fields %>
-                <% if $Tabs %>
-                    <% loop $Tabs %>
-                        <% if $Tabs %>
-                            $FieldHolder
-                        <% else %>
-                            <div $AttributesHTML>
-                                <% loop $Fields %>
-                                    $FieldHolder
-                                <% end_loop %>
-                            </div>
-                        <% end_if %>
-                    <% end_loop %>
-                <% else %>
-                    $FieldHolder
-                <% end_if %>
+                $FieldHolder
             <% end_loop %>
             <div class="clear"><!-- --></div>
         </fieldset>
@@ -34,7 +20,7 @@
         <% if $Actions %>
             <div class="btn-toolbar">
                 <% loop $Actions %>
-                    $Field
+                    $FieldHolder
                 <% end_loop %>
                 <% if $Controller.LinkPreview %>
                     <a href="$Controller.LinkPreview" class="cms-preview-toggle-link ss-ui-button" data-icon="preview">


### PR DESCRIPTION
Added back link method for grid field back button to use, changed template to match what CMSMain uses for its edit view which fixes jquery tab error.